### PR TITLE
Fixed a issue which cause rule loading failed when the engine is using pre-parsed COs

### DIFF
--- a/ResourceStaticAnalysis/src/ResourceStaticAnalysisCore/Engine/ResourceStaticAnalysisEngine.cs
+++ b/ResourceStaticAnalysis/src/ResourceStaticAnalysisCore/Engine/ResourceStaticAnalysisEngine.cs
@@ -72,18 +72,18 @@ namespace Microsoft.ResourceStaticAnalysis.Core.Engine
         private readonly ManualResetEvent _coProcessingDone = new ManualResetEvent(false);
 
         private readonly ManualResetEvent _allOutputFinished = new ManualResetEvent(false);
-        
+
         /// <summary>
         /// DataAdapters are stored here; mapped from ClassificationObject type they create to a list of instances of adapters.
         /// There can be more than one type of data adapter producing the same CO type, as they may cover different data source combinations.
         /// </summary>
         private readonly Dictionary<Type, IList<ClassificationObjectAdapter>> _coAdapters = new Dictionary<Type, IList<ClassificationObjectAdapter>>();
-        
+
         /// <summary>
         /// The queue of DataSourcePackage objects that needs to be provided to ResourceStaticAnalysis Engine;
         /// </summary>
         private readonly Queue<DataSourcePackage> _dataSourcePackages;
-        
+
         /// <summary>
         /// Stores instances of Space for each type of Classification Object loaded by the engine.
         /// </summary>
@@ -96,12 +96,12 @@ namespace Microsoft.ResourceStaticAnalysis.Core.Engine
         /// ClassificationObject types known to the engine. These are configured using ResourceStaticAnalysis config.
         /// </summary>
         internal Dictionary<string, Type> _coTypes = new Dictionary<string, Type>();
-        
+
         /// <summary>
         /// Stores instances of output writers as defined in engine config.
         /// </summary>
         internal List<IOutputWriter> _outputWriters = new List<IOutputWriter>();
-        
+
         /// <summary>
         /// Engine config specified during construction time. Engine then organizes the creation of Spaces and COs based on the packages
         /// </summary>
@@ -139,6 +139,8 @@ namespace Microsoft.ResourceStaticAnalysis.Core.Engine
                 if (preLoadedCOs)
                 {
                     _usePreLoadedCOs = true;
+                    //Register ClassificationObject types
+                    RegisterCOTypes();
                     //Create instances of output writers
                     RegisterOutputWriters();
                 }
@@ -434,7 +436,7 @@ namespace Microsoft.ResourceStaticAnalysis.Core.Engine
         /// DataSourceProviders are stored here; mapped from Data Source type name they create to instance of provider.
         /// </summary>
         private readonly Dictionary<string, IDataSourceProvider> _dataSourceProviders = new Dictionary<string, IDataSourceProvider>();
-        
+
         /// <summary>
         /// Creates instances of data source provides based on the DataSourceProvider assemblies and stores them in a dictionary
         /// </summary>
@@ -550,7 +552,7 @@ namespace Microsoft.ResourceStaticAnalysis.Core.Engine
             //Therefore in multi-thread scenario each rule will be invoked as a separate job on the entire set of
             //COs. this may be less efficient in some cases, but allows us to preserve the current design.
             CurrentRuleManager.ClassifyObjectsAsynchronously(_preProcessedInput, ClassifyObjectsDone);
-            
+
             //we let the thread return, we will finalize engine asynchronously when all objects have been processed
             return;
         }

--- a/ResourceStaticAnalysis/src/UnitTests/TestHelpers.cs
+++ b/ResourceStaticAnalysis/src/UnitTests/TestHelpers.cs
@@ -6,8 +6,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.ResourceStaticAnalysis.UnitTests.TestObjectStructure;
+using Microsoft.ResourceStaticAnalysis.Core.DataSource;
 using Microsoft.ResourceStaticAnalysis.Core.DataSource.DataSourcePackages;
 using Microsoft.ResourceStaticAnalysis.Core.Engine;
 using Microsoft.ResourceStaticAnalysis.Core.Output;
@@ -27,7 +29,7 @@ namespace Microsoft.ResourceStaticAnalysis.UnitTests
         internal static EngineConfig CreateSampleConfig(TestContext testContext, string testRuleFileName, int numberOfResources)
         {
             testRuleFileName = Path.Combine(testContext.DeploymentDirectory, testRuleFileName);
-            
+
             var configuration = new EngineConfig();
 
             #region DataSourceProviderTypes
@@ -98,6 +100,16 @@ namespace Microsoft.ResourceStaticAnalysis.UnitTests
         }
 
         /// <summary>
+        /// Generate a List of <see cref="ClassificationObject"/>.
+        /// </summary>
+        /// <param name="numberOfResources">Number of Resources to generate (in increments of 6)</param>
+        /// <returns>A list of <see cref="ClassificationObject"/>.</returns>
+        internal static List<ClassificationObject> GenerateParesdCOs(int numberOfResources)
+        {
+            return ParseResStrInfoToCOs(GenerateLargeNumberOfResources(numberOfResources)).Cast<ClassificationObject>().ToList();
+        }
+
+        /// <summary>
         /// Generates a List of Tuple to be converted to ResourceEntries during execution (minimum of 6)
         /// </summary>
         /// <param name="numResources"></param>
@@ -109,17 +121,40 @@ namespace Microsoft.ResourceStaticAnalysis.UnitTests
                 throw new Exception("Method generates a minimum of 6 Tuples");
             }
             List<Tuple<string, string, string>> results = new List<Tuple<string, string, string>>();
-            for (int i = 1; i <= numResources; i+=6)
+            for (int i = 1; i <= numResources; i += 6)
             {
                 results.Add(new Tuple<string, string, string>("Item" + i.ToString(), "foo", "descriptive comment"));
-                results.Add(new Tuple<string, string, string>("Item" + ( i + 1).ToString(), "foo", "foo"));
-                results.Add(new Tuple<string, string, string>("Itm" + (i + 2).ToString(), "foo", "foo"));
+                results.Add(new Tuple<string, string, string>("Item" + (i + 1).ToString(), "foo", "foo"));
+                results.Add(new Tuple<string, string, string>("Item" + (i + 2).ToString(), "foo", "foo"));
                 results.Add(new Tuple<string, string, string>("Item" + (i + 3).ToString(), "foobar", "foobar"));
                 results.Add(new Tuple<string, string, string>("Item" + (i + 4).ToString(), "foobar", "foo"));
                 results.Add(new Tuple<string, string, string>("Item" + (i + 5).ToString(), "xyz", "no vowels"));
             }
 
             return results;
+        }
+
+        /// <summary>
+        /// This method is used to parse a list of tuple to a list of <see cref="SampleClassificationObjectType"/>.
+        /// </summary>
+        /// <param name="sampleResources">A list of tuple to be parsed.</param>
+        /// <returns>A list of <see cref="SampleClassificationObjectType"/>.</returns>
+        private static List<SampleClassificationObjectType> ParseResStrInfoToCOs(List<Tuple<string, string, string>> resourceTuples)
+        {
+            SampleResourceCollection sampleResourceCollection = new SampleResourceCollection(resourceTuples);
+
+            List<SampleClassificationObjectType> sampleClassificationObjects = new List<SampleClassificationObjectType>();
+
+            SamplePropertyAdapter samplePropertyAdapter = new SamplePropertyAdapter();
+            sampleResourceCollection.Entries.ForEach(sampleResource =>
+            {
+                PropertyProvider propertyProvider = new PropertyProvider();
+                propertyProvider.AddPropertyAdapterDataSourcePair(samplePropertyAdapter, sampleResource);
+                SampleClassificationObjectType sampleClassificationObject = new SampleClassificationObjectType(propertyProvider);
+                sampleClassificationObjects.Add(sampleClassificationObject);
+            });
+
+            return sampleClassificationObjects;
         }
     }
 }


### PR DESCRIPTION
Added RegisterCOTypes(); when preLoadedCOs is true.
UnitTests are also included.