### PR TITLE
Change the method of getting ResourceStaticAnalysisConfigMacros.xml path

### DIFF
--- a/ResourceStaticAnalysis/src/ResourceStaticAnalysisConfiguration/ResourceStaticAnalysisConfigMacroHandler.cs
+++ b/ResourceStaticAnalysis/src/ResourceStaticAnalysisConfiguration/ResourceStaticAnalysisConfigMacroHandler.cs
@@ -244,7 +244,7 @@ namespace Microsoft.ResourceStaticAnalysis.Configuration
         private ResourceStaticAnalysisConfigMacros LoadConfigMacros()
         {
             Assembly assembly = Assembly.GetExecutingAssembly();
-            String pathToFile = Path.Combine(Path.GetDirectoryName(assembly.Location), macroDefinitionFile);
+            String pathToFile = Path.Combine(Path.GetDirectoryName(new Uri(assembly.CodeBase).LocalPath), macroDefinitionFile);
 
             ResourceStaticAnalysisConfigMacros macros = null;
             if (!File.Exists(pathToFile) || (macros = ResourceStaticAnalysisConfigMacros.Load(pathToFile)) == null)

--- a/ResourceStaticAnalysis/src/ResourceStaticAnalysisConfiguration/ResourceStaticAnalysisConfiguration.csproj
+++ b/ResourceStaticAnalysis/src/ResourceStaticAnalysisConfiguration/ResourceStaticAnalysisConfiguration.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.ResourceStaticAnalysis.Configuration</RootNamespace>
     <AssemblyName>Microsoft.ResourceStaticAnalysis.Configuration</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/ResourceStaticAnalysis/src/UnitTests/TestMacroFile/ResourceStaticAnalysisConfigMacros.xml
+++ b/ResourceStaticAnalysis/src/UnitTests/TestMacroFile/ResourceStaticAnalysisConfigMacros.xml
@@ -1,0 +1,5 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. -->
+<!-- See LICENSE in the project root for license information -->
+<Macros>
+  <Macro name="DummyMacro" value="DummyValue1;DummyValue2" />
+</Macros>

--- a/ResourceStaticAnalysis/src/UnitTests/Tests/BasicTests.cs
+++ b/ResourceStaticAnalysis/src/UnitTests/Tests/BasicTests.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Practices.AssemblyManagement;
+using Microsoft.ResourceStaticAnalysis.Configuration;
 using Microsoft.ResourceStaticAnalysis.Core.Engine;
 using Microsoft.ResourceStaticAnalysis.Core.Misc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -236,6 +237,19 @@ namespace Microsoft.ResourceStaticAnalysis.UnitTests.Tests
                 Assert.Fail("ResourceStaticAnalysis engine failed because {0}", ex.Message);
             }
         }
+
+        /// <summary>
+        /// Test method to ensure that macro xml files stored along with the assembly can be loaded correctly
+        /// </summary>
+        [TestMethod]
+        [DeploymentItem(@"TestMacroFile\ResourceStaticAnalysisConfigMacros.xml")]
+        public void ResourceStaticAnalysisCanLoadMacroXMLFileFromCodeBaseLocation()
+        {
+            var resourceStaticAnalysisConfigMacroHandler = ResourceStaticAnalysisConfigMacroHandler.Instance;
+            var expandedMacro = resourceStaticAnalysisConfigMacroHandler.ExpandMacros("@DummyMacro@");
+            Assert.IsTrue(expandedMacro == "DummyValue1;DummyValue2");
+        }
+
     }
 }
 

--- a/ResourceStaticAnalysis/src/UnitTests/UnitTests.csproj
+++ b/ResourceStaticAnalysis/src/UnitTests/UnitTests.csproj
@@ -97,11 +97,18 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="AuthoringTests.txt" />
+    <Content Include="TestMacroFile\ResourceStaticAnalysisConfigMacros.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AssemblyResolver\AssemblyResolver.csproj">
       <Project>{dcba9d95-4cc1-4079-9bc1-cadfa34127e2}</Project>
       <Name>AssemblyResolver</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ResourceStaticAnalysisConfiguration\ResourceStaticAnalysisConfiguration.csproj">
+      <Project>{698421ce-40f2-46f8-9d7c-2384f2f681cb}</Project>
+      <Name>ResourceStaticAnalysisConfiguration</Name>
     </ProjectReference>
     <ProjectReference Include="..\ResourceStaticAnalysisCore\ResourceStaticAnalysisCore.csproj">
       <Project>{5a4a8fc1-cfaf-4faf-8099-de5dd8d0870b}</Project>


### PR DESCRIPTION
Change the method of getting `ResourceStaticAnalysisConfigMacros.xml` path to make it easier to use in web.
Add a unit test to test the file is loaded correctly.

P.s.
The `Microsoft.ResourceStaticAnalysis.Configuration` was compiled into 4.5.2 which is inconsistent with other projects, thus it cannot be loaded to unit test project which is also .net 4.5. I changed the Configuration project to 4.5.
 