### PR TITLE
Update the comments to reflect the code logic

### DIFF
--- a/ResourceStaticAnalysis/src/ResourceStaticAnalysisCore/Output/OutputWriter.cs
+++ b/ResourceStaticAnalysis/src/ResourceStaticAnalysisCore/Output/OutputWriter.cs
@@ -78,8 +78,8 @@ namespace Microsoft.ResourceStaticAnalysis.Core.Output
         /// <summary>
         /// Calculates the overall result of running the rule on a single CO.
         /// </summary>
-        /// <remarks>The values of each Check() result are AND'ed to create the overall result.
-        /// That is, if all Check() calls returned True, then the result for the whole rule is set to True.
+        /// <remarks>The values of each Check() result are OR'ed to create the overall result.
+        /// That is, if any Check() call returned True, then the result for the whole rule is set to True.
         /// </remarks>
         /// <returns></returns>
         public bool SetTrueOrFalse()


### PR DESCRIPTION
I believe the comment is not aligned with the logic of the method `SetTrueOrFalse()` (The Operand is OR and it OR the `Result` value in each `OutputItem`)